### PR TITLE
Use List.from() to create 100k-element rrbit List

### DIFF
--- a/perf/concatPerf.js
+++ b/perf/concatPerf.js
@@ -18,7 +18,7 @@ var BASE = {
 	'immutable': Imm.fromJS(LRG),
 	'seamless': seamless.from(LRG),
 	'mori': mori.toClj(LRG),
-	'rrb': List.of(LRG)
+	'rrb': List.from(LRG)
 
 }
 


### PR DESCRIPTION
Hey @wishfoundry, rrbit looks really cool.  I'll def be keeping an eye on it.

I found that the concatPerf test is using `List.of` instead of `List.from`.  It's concatenating 2 rrbit Lists of length 1, rather than two Lists of length 100k.  After switching to `List.from`, rrbit *still does very well*, however it does make anywhere from 4-10x difference on my system (os x 10.12.2, node 6.9.1).

Cheers